### PR TITLE
Removes mod key from application file

### DIFF
--- a/src/metal.app.src
+++ b/src/metal.app.src
@@ -5,7 +5,6 @@
   {licenses, ["MIT"]},
   {links, [{"GitHub", "https://github.com/lpgauth/metal"}]},
   {maintainers, ["Louis-Philippe Gauthier"]},
-  {mod, []},
   {registered, []},
   {vsn, "0.1.0"}
 ]}.


### PR DESCRIPTION
Since metal is a library application there is no process to start therefore there is no need for a mod key in application file